### PR TITLE
Honour files excluded via the SwiftLint config file

### DIFF
--- a/Sources/TuistPluginSwiftLintFramework/SwiftLintFrameworkAdapter/SwiftLintFrameworkAdapter.swift
+++ b/Sources/TuistPluginSwiftLintFramework/SwiftLintFrameworkAdapter/SwiftLintFrameworkAdapter.swift
@@ -86,9 +86,8 @@ public final class SwiftLintFrameworkAdapter: SwiftLintFrameworkAdapting {
             queuedPrintError("Linting Swift files \(filesInfo)")
         }
 
-        // The SwiftLint CLI works out the files to lint, they can be excluded via the config file, but if you mention files to lint it will
-        // override the config. The forceExclude flag allows the config file to still apply. As the plguin always specifies the files to lint,
-        // without forceExclude being true users will be unable to exclude files via the config file.
+        // When passing a list of file to SwiftLint, the `forceExclude` flag must be set to true to exclude files that are
+        // excluded via configuration file.
         return paths.flatMap {
             configuration.lintableFiles(inPath: $0, forceExclude: true)
         }


### PR DESCRIPTION
Closes #12.

The SwiftLint CLI works out the files to lint and the user can make files as excluded from linting via the config file `excluded` section. However, if a file is specified to the CLI it will be linted regardless of the config. The forceExclude flag ensures the config is always applied and so a specified file will be skipped if the config file says it should be excluded.

The Tuist plugin runs SwiftLint via specifying all the files to lint, this means that with forceExclude set to false (as it was previously), the excluded section in config file won't work and will always be ignored, as all files are specified.

This PR changes forceExclude to be true, which makes sense due to how the plugin is used. With no excluded in config it will run as the plugin already did, with files excluded in config then it will be honoured. Previously, the config file excluded files was ignored and meant the plugin couldn't be used for users who needed to exclude some files.